### PR TITLE
refactor: format source codes by black

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,10 +100,29 @@ jobs:
           cache: 'pip' # caching pip dependencies
       - name: python package installation
         run: |
-          pip install -e.[docs]
+          pip install -e.[dev]
       - name: rst2html5.py --strict README.rst >/dev/null
         run: |
           rst2html5.py --strict README.rst >/dev/null
+
+  black-22:
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        python_version:
+          - "3.11"
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python_version }}
+          cache: 'pip' # caching pip dependencies
+      - name: python package installation
+        run: |
+          pip install -e.[dev]
+      - name: black .
+        run: |
+          black .
 
   build-22:
     runs-on: ubuntu-22.04

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ var/
 *.egg
 .env/
 .mypy_cache/
+venv/
+.venv/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,8 +48,16 @@ classifiers = [
 
 [project.optional-dependencies]
 develop = ["hacking", "flake8-docstrings", "pep8-naming"]
-dev = ["pytest", "pylint", "mypy", "setuptools", "types-setuptools", "coverage"]
-docs = ["docutils"]
+dev = [
+  "black>=23.7.0",
+  "coverage",
+  "docutils",
+  "mypy>=0.560",
+  "pylint>=2.6.0",
+  "pytest",
+  "setuptools>=61.0",
+  "types-setuptools",
+]
 
 [project.urls]
 Homepage = "https://github.com/ma8ma/yanico"
@@ -68,5 +76,12 @@ exclude = ["tests"]
 [tool.setuptools.dynamic]
 version = {attr = "yanico.__version__"}
 
-[tool.flake8]
-ignore = "D203"
+[tool.black]
+line-length = 88
+target-version = ["py38", "py39", "py310", "py311", "py312"]
+
+[tool.mypy]
+python_version = "3.8"
+
+[tool.pylint.format]
+max-line-length = "88"

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -27,24 +27,24 @@ class TestCreateMainParser(unittest.TestCase):
     def test_version(self):
         """Parse '--version' option."""
         parser = yanico.command.create_main_parser()
-        with mock.patch.object(parser, '_print_message') as print_message:
-            self.assertRaises(SystemExit, parser.parse_args, ['--version'])
-        print_message.assert_called_once_with('yanico version ' +
-                                              yanico.__version__ + '\n',
-                                              mock.ANY)
+        with mock.patch.object(parser, "_print_message") as print_message:
+            self.assertRaises(SystemExit, parser.parse_args, ["--version"])
+        print_message.assert_called_once_with(
+            "yanico version " + yanico.__version__ + "\n", mock.ANY
+        )
 
     def test_help_long(self):
         """Parse '--help' option."""
         parser = yanico.command.create_main_parser()
-        with mock.patch.object(parser, 'print_help') as print_help:
-            self.assertRaises(SystemExit, parser.parse_args, ['--help'])
+        with mock.patch.object(parser, "print_help") as print_help:
+            self.assertRaises(SystemExit, parser.parse_args, ["--help"])
         print_help.assert_called_once_with()
 
     def test_help_short(self):
         """Parse '-h' option."""
         parser = yanico.command.create_main_parser()
-        with mock.patch.object(parser, 'print_help') as print_help:
-            self.assertRaises(SystemExit, parser.parse_args, ['-h'])
+        with mock.patch.object(parser, "print_help") as print_help:
+            self.assertRaises(SystemExit, parser.parse_args, ["-h"])
         print_help.assert_called_once_with()
 
     @staticmethod
@@ -52,7 +52,7 @@ class TestCreateMainParser(unittest.TestCase):
         """Expect 'run' method that showing help."""
         parser = yanico.command.create_main_parser()
         args = parser.parse_args([])
-        with mock.patch.object(parser, 'print_help') as print_help:
+        with mock.patch.object(parser, "print_help") as print_help:
             args.run(args)
         print_help.assert_called_once_with()
 
@@ -63,6 +63,7 @@ class TestBuildSubparsers(unittest.TestCase):
     @staticmethod
     def _init_stub_command():
         """Return entry point having stub command."""
+
         def run(args):
             """Command body."""
             return args.n * 2
@@ -70,26 +71,26 @@ class TestBuildSubparsers(unittest.TestCase):
         def register(command_name, subparsers):
             """Command registrant."""
             parser = subparsers.add_parser(command_name)
-            parser.add_argument('n', type=int)
+            parser.add_argument("n", type=int)
             parser.set_defaults(run=run)
 
         entry_point = mock.Mock()
-        entry_point.name = 'stub'
+        entry_point.name = "stub"
         entry_point.load.return_value = register
         return entry_point
 
-    @mock.patch('pkg_resources.iter_entry_points')
+    @mock.patch("pkg_resources.iter_entry_points")
     def test_stub_command(self, iter_entry_points):
         """Register command returning two times numbers."""
         iter_entry_points.return_value = [self._init_stub_command()]
 
         parser = argparse.ArgumentParser()
         yanico.command.build_subparsers(parser)
-        args = parser.parse_args(['stub', '21'])
+        args = parser.parse_args(["stub", "21"])
         self.assertEqual(args.run(args), 42)
-        iter_entry_points.assert_called_once_with('yanico.commands')
+        iter_entry_points.assert_called_once_with("yanico.commands")
 
-    @mock.patch('pkg_resources.iter_entry_points')
+    @mock.patch("pkg_resources.iter_entry_points")
     def test_without_arguments(self, iter_entry_points):
         """Expect 'run' method that showing help."""
         iter_entry_points.return_value = [self._init_stub_command()]
@@ -97,10 +98,10 @@ class TestBuildSubparsers(unittest.TestCase):
         parser = yanico.command.create_main_parser()
         yanico.command.build_subparsers(parser)
         args = parser.parse_args([])
-        with mock.patch.object(parser, 'print_help') as print_help:
+        with mock.patch.object(parser, "print_help") as print_help:
             args.run(args)
         print_help.assert_called_once_with()
-        iter_entry_points.assert_called_once_with('yanico.commands')
+        iter_entry_points.assert_called_once_with("yanico.commands")
 
 
 class TestMain(unittest.TestCase):
@@ -111,14 +112,14 @@ class TestMain(unittest.TestCase):
         """Return parser having command that returns integer."""
         parser = argparse.ArgumentParser()
         subparsers = parser.add_subparsers()
-        stub_parser = subparsers.add_parser('stub')
-        stub_parser.add_argument('n', type=int)
+        stub_parser = subparsers.add_parser("stub")
+        stub_parser.add_argument("n", type=int)
         stub_parser.set_defaults(run=lambda args: args.n)
         return parser
 
-    @mock.patch('yanico.command.create_main_parser')
-    @mock.patch('yanico.command.build_subparsers')
-    @mock.patch('sys.argv', new=['', 'stub', '3'])
+    @mock.patch("yanico.command.create_main_parser")
+    @mock.patch("yanico.command.build_subparsers")
+    @mock.patch("sys.argv", new=["", "stub", "3"])
     def test_return_value(self, _, create_main_parser):
         """Except main function returns specified integer."""
         create_main_parser.return_value = self._init_stub_parser()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -23,28 +23,28 @@ from yanico import config
 class TestUserPath(unittest.TestCase):
     """Test for yanico.config.user_path()."""
 
-    @mock.patch.dict(os.environ, {'HOME': 'spam'})
+    @mock.patch.dict(os.environ, {"HOME": "spam"})
     def test_path(self):
         """Expect filepath joinning '.yanico.conf' under $HOME."""
         expect = None
-        if os.sep == '\\':
-            expect = 'spam\\.yanico.conf'
-        elif os.sep == '/':
-            expect = 'spam/.yanico.conf'
+        if os.sep == "\\":
+            expect = "spam\\.yanico.conf"
+        elif os.sep == "/":
+            expect = "spam/.yanico.conf"
         result = config.user_path()
         self.assertEqual(result, expect)
 
-    @mock.patch('yanico.config.CONFIG_FILENAME', new='ham.egg')
+    @mock.patch("yanico.config.CONFIG_FILENAME", new="ham.egg")
     def test_dependence_constants(self):
         """Expect to depend filename by 'CONFIG_FILENAME' constants."""
         result = config.user_path()
-        self.assertEqual(os.path.basename(result), 'ham.egg')
+        self.assertEqual(os.path.basename(result), "ham.egg")
 
 
 class TestLoad(unittest.TestCase):
     """Test for yanico.config.load()."""
 
-    @mock.patch('configparser.ConfigParser')
+    @mock.patch("configparser.ConfigParser")
     def test_without_args(self, parserclass):
         """Expect config object that tried to parse user config file."""
         mock_conf = parserclass.return_value
@@ -52,11 +52,12 @@ class TestLoad(unittest.TestCase):
         self.assertIs(result, mock_conf)
         mock_conf.read.assert_called_once_with((config.user_path(),))
 
-    @mock.patch('configparser.ConfigParser')
+    @mock.patch("configparser.ConfigParser")
     def test_with_args(self, parserclass):
         """Expect arguments pass to the parser after user config file."""
         mock_conf = parserclass.return_value
-        result = config.load('spam', 'ham', 'eggs')
+        result = config.load("spam", "ham", "eggs")
         self.assertIs(result, mock_conf)
-        mock_conf.read.assert_called_once_with((config.user_path(),
-                                                'spam', 'ham', 'eggs'))
+        mock_conf.read.assert_called_once_with(
+            (config.user_path(), "spam", "ham", "eggs")
+        )

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -23,46 +23,48 @@ from yanico.session import LoaderNotFoundError
 class TestLoad(unittest.TestCase):
     """Test for yanico.session.load()."""
 
-    @mock.patch('pkg_resources.iter_entry_points')
+    @mock.patch("pkg_resources.iter_entry_points")
     def test_loader_exist(self, iter_eps):
         """Expect to the load function returns user session."""
         entry = mock.Mock()
-        loader = entry.load.return_value = mock.Mock(return_value='value')
+        loader = entry.load.return_value = mock.Mock(return_value="value")
         iter_eps.return_value = [entry]
 
-        ltype = 'firefox'
-        profile = '/path/to/profile'
-        self.assertEqual(session.load(ltype, profile), 'value')
+        ltype = "firefox"
+        profile = "/path/to/profile"
+        self.assertEqual(session.load(ltype, profile), "value")
 
-        iter_eps.assert_called_once_with('yanico.sessions', ltype)
+        iter_eps.assert_called_once_with("yanico.sessions", ltype)
         entry.load.assert_called_once_with()
         loader.assert_called_once_with(profile)
 
-    @mock.patch('pkg_resources.iter_entry_points')
+    @mock.patch("pkg_resources.iter_entry_points")
     def test_loader_not_exist(self, iter_eps):
         """Expect to raise exception when the loader does not exist."""
         iter_eps.return_value = []
 
-        ltype = 'loader is not found'
-        profile = 'dummy'
+        ltype = "loader is not found"
+        profile = "dummy"
         self.assertRaises(LoaderNotFoundError, session.load, ltype, profile)
 
-        iter_eps.assert_called_once_with('yanico.sessions', ltype)
+        iter_eps.assert_called_once_with("yanico.sessions", ltype)
 
-    @mock.patch('pkg_resources.iter_entry_points')
+    @mock.patch("pkg_resources.iter_entry_points")
     def test_loader_error(self, iter_eps):
         """Expect to through error when the loader raises any error."""
+
         class _AnyError(Exception):
             pass
+
         entry = mock.Mock()
         loader = entry.load.return_value = mock.Mock(side_effect=_AnyError)
         iter_eps.return_value = [entry]
 
-        ltype = 'loader is found'
-        profile = 'a profile'
+        ltype = "loader is found"
+        profile = "a profile"
         self.assertRaises(_AnyError, session.load, ltype, profile)
 
-        iter_eps.assert_called_once_with('yanico.sessions', ltype)
+        iter_eps.assert_called_once_with("yanico.sessions", ltype)
         entry.load.assert_called_once_with()
         loader.assert_called_once_with(profile)
 
@@ -70,29 +72,27 @@ class TestLoad(unittest.TestCase):
 class TestLoadFromConfig(unittest.TestCase):
     """Test for yanico.session.load_from_config()."""
 
-    @mock.patch('yanico.session.load')
+    @mock.patch("yanico.session.load")
     def test_min_config(self, load_func):
         """Expect to return string using minimum configuration."""
-        load_func.return_value = 'value'
+        load_func.return_value = "value"
 
-        min_config = {
-            'session': {'type': 'foobar', 'profile': '/path/to/profile'}
-        }
-        self.assertEqual(session.load_from_config(min_config), 'value')
+        min_config = {"session": {"type": "foobar", "profile": "/path/to/profile"}}
+        self.assertEqual(session.load_from_config(min_config), "value")
 
-        load_func.assert_called_once_with('foobar', '/path/to/profile')
+        load_func.assert_called_once_with("foobar", "/path/to/profile")
 
     def test_without_session(self):
         """Expect to raise KeyError if the config without session."""
-        without_session = {'type': 'foobar', 'profile': '/path/to/profile'}
+        without_session = {"type": "foobar", "profile": "/path/to/profile"}
         self.assertRaises(KeyError, session.load_from_config, without_session)
 
     def test_without_type(self):
         """Expect to raise KeyError if the config without type."""
-        without_type = {'session': {'profile': '/path/to/profile'}}
+        without_type = {"session": {"profile": "/path/to/profile"}}
         self.assertRaises(KeyError, session.load_from_config, without_type)
 
     def test_without_profile(self):
         """Expect to raise KeyError if the config without profile."""
-        without_profile = {'session': {'type': 'foobar'}}
+        without_profile = {"session": {"type": "foobar"}}
         self.assertRaises(KeyError, session.load_from_config, without_profile)

--- a/tests/test_session_firefox.py
+++ b/tests/test_session_firefox.py
@@ -25,7 +25,7 @@ from yanico.session import UserSessionNotFoundError
 
 
 def _stub_db():
-    conn = sqlite3.connect(':memory:')
+    conn = sqlite3.connect(":memory:")
     conn.execute("CREATE TABLE moz_cookies (name, host, value)")
     return conn
 
@@ -36,32 +36,35 @@ class TestLoad(unittest.TestCase):
     def test_exist(self):
         """Expect user_session string."""
         conn = _stub_db()
-        conn.execute("INSERT INTO moz_cookies VALUES"
-                     "('user_session', '.nicovideo.jp', 'dummy_user_session')")
-        with mock.patch('sqlite3.connect') as mock_connect:
+        conn.execute(
+            "INSERT INTO moz_cookies VALUES"
+            "('user_session', '.nicovideo.jp', 'dummy_user_session')"
+        )
+        with mock.patch("sqlite3.connect") as mock_connect:
             mock_connect.return_value = conn
-            ses = firefox.load('/path/to/profile')
-        expect_path = os.path.join('/path/to/profile', 'cookies.sqlite')
+            ses = firefox.load("/path/to/profile")
+        expect_path = os.path.join("/path/to/profile", "cookies.sqlite")
         mock_connect.assert_called_once_with(expect_path)
-        self.assertEqual('dummy_user_session', ses)
+        self.assertEqual("dummy_user_session", ses)
 
     def test_not_exist(self):
         """If not exist user_session, raise Error."""
         conn = _stub_db()
-        with mock.patch('sqlite3.connect') as mock_connect:
+        with mock.patch("sqlite3.connect") as mock_connect:
             mock_connect.return_value = conn
-            self.assertRaises(UserSessionNotFoundError,
-                              firefox.load, '/path/to/profile')
-        expect_path = os.path.join('/path/to/profile', 'cookies.sqlite')
+            self.assertRaises(
+                UserSessionNotFoundError, firefox.load, "/path/to/profile"
+            )
+        expect_path = os.path.join("/path/to/profile", "cookies.sqlite")
         mock_connect.assert_called_once_with(expect_path)
 
     def test_not_directory(self):
         """If profile is not directory path, raise Error."""
-        self.assertRaises(FileNotFoundError, firefox.load, '/NOT-DIRECTORY')
+        self.assertRaises(FileNotFoundError, firefox.load, "/NOT-DIRECTORY")
 
     def test_empty_string(self):
         """If profile is empty string, raise Error."""
-        self.assertRaises(FileNotFoundError, firefox.load, '')
+        self.assertRaises(FileNotFoundError, firefox.load, "")
 
 
 class TestEntryPoint(unittest.TestCase):
@@ -69,6 +72,7 @@ class TestEntryPoint(unittest.TestCase):
 
     def test_load_func(self):
         """Check whether loaeded function is firefox.load()."""
-        func = pkg_resources.load_entry_point('yanico>=0.1.0a2',
-                                              'yanico.sessions', 'firefox')
+        func = pkg_resources.load_entry_point(
+            "yanico>=0.1.0a2", "yanico.sessions", "firefox"
+        )
         self.assertIs(firefox.load, func)

--- a/yanico/__init__.py
+++ b/yanico/__init__.py
@@ -13,8 +13,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-__author__ = 'Masayuki Yamamoto'
-__copyright__ = 'Copyright 2015-2016 Yamamoto Masayuki'
+__author__ = "Masayuki Yamamoto"
+__copyright__ = "Copyright 2015-2016 Yamamoto Masayuki"
 __description__ = __doc__
-__license__ = 'Apache 2.0'
-__version__ = '0.1.0a4'
+__license__ = "Apache 2.0"
+__version__ = "0.1.0a4"

--- a/yanico/__main__.py
+++ b/yanico/__main__.py
@@ -17,5 +17,5 @@ import sys
 
 import yanico.command
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(yanico.command.main())

--- a/yanico/command/__init__.py
+++ b/yanico/command/__init__.py
@@ -23,10 +23,11 @@ def create_main_parser():
     """Return command argument parser."""
     parser = argparse.ArgumentParser(
         description=yanico.__description__,
-        prog='yan',
+        prog="yan",
     )
-    parser.add_argument('--version', action='version',
-                        version='yanico version ' + yanico.__version__)
+    parser.add_argument(
+        "--version", action="version", version="yanico version " + yanico.__version__
+    )
     parser.set_defaults(run=lambda _: parser.print_help())
     return parser
 
@@ -34,8 +35,8 @@ def create_main_parser():
 def build_subparsers(parser):
     """Register command from setuptools plugins."""
     # pylint: disable=no-member
-    subparsers = parser.add_subparsers(title='Commands')
-    for entry in pkg_resources.iter_entry_points('yanico.commands'):
+    subparsers = parser.add_subparsers(title="Commands")
+    for entry in pkg_resources.iter_entry_points("yanico.commands"):
         register = entry.load()
         register(entry.name, subparsers)
 

--- a/yanico/config.py
+++ b/yanico/config.py
@@ -17,7 +17,7 @@ import configparser
 import os.path
 
 
-CONFIG_FILENAME = '.yanico.conf'
+CONFIG_FILENAME = ".yanico.conf"
 
 
 def user_path():
@@ -25,7 +25,7 @@ def user_path():
 
     The filepath depends home directory and CONFIG_FILENAME constants.
     """
-    return os.path.join(os.path.expanduser('~'), CONFIG_FILENAME)
+    return os.path.join(os.path.expanduser("~"), CONFIG_FILENAME)
 
 
 def load(*filepaths):

--- a/yanico/session/__init__.py
+++ b/yanico/session/__init__.py
@@ -38,10 +38,10 @@ def load(ltype, profile):
         LoaderNotFoundError
         Error from loader
     """
-    for entry in pkg_resources.iter_entry_points('yanico.sessions', ltype):
+    for entry in pkg_resources.iter_entry_points("yanico.sessions", ltype):
         load_func = entry.load()
         return load_func(profile)
-    raise LoaderNotFoundError(f'{ltype} loader is not found.')
+    raise LoaderNotFoundError(f"{ltype} loader is not found.")
 
 
 def load_from_config(conf):
@@ -58,5 +58,5 @@ def load_from_config(conf):
         KeyError
         Error from load()
     """
-    session = conf['session']
-    return load(session['type'], session['profile'])
+    session = conf["session"]
+    return load(session["type"], session["profile"])

--- a/yanico/session/firefox.py
+++ b/yanico/session/firefox.py
@@ -32,16 +32,17 @@ def load(profile):
     UserSessionNotFoundError
     """
     if not profile:
-        raise FileNotFoundError('profile must not be empty.')
-    cookie_path = os.path.join(profile, 'cookies.sqlite')
+        raise FileNotFoundError("profile must not be empty.")
+    cookie_path = os.path.join(profile, "cookies.sqlite")
     try:
         conn = sqlite3.connect(cookie_path)
     except sqlite3.OperationalError as exc:
-        raise FileNotFoundError(f'{profile} is not directory.') from exc
+        raise FileNotFoundError(f"{profile} is not directory.") from exc
     cur = conn.execute(
         "SELECT value FROM moz_cookies "
-        "WHERE name = 'user_session' AND host = '.nicovideo.jp'")
+        "WHERE name = 'user_session' AND host = '.nicovideo.jp'"
+    )
     row = cur.fetchone()
     if not row:
-        raise UserSessionNotFoundError('user_session is not found.')
+        raise UserSessionNotFoundError("user_session is not found.")
     return row[0]


### PR DESCRIPTION
Delegate code formatting to The Uncompromising Code Formatter [black][1] (use in default configurations).

[1]: https://pypi.org/project/black/
