### PR TITLE
Use importlib.metadata instead of deprecated pkg_resources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,8 @@ jobs:
           cache: 'pip' # caching pip dependencies
       - name: python package installation
         run: |
-          pip install -e.[dev]
+          # Cannot find implementation or library stub for module named "importlib_metadata" (python_version < "3.10")
+          pip install -e.[dev] importlib-metadata
       - name: mypy yanico/ --install-types
         run: |
           mypy yanico/ --install-types

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,8 @@ jobs:
           cache: 'pip' # caching pip dependencies
       - name: python package installation
         run: |
-          pip install -e.[dev]
+          # Cannot find implementation or library stub for module named "importlib_metadata" (python_version < "3.10")
+          pip install -e.[dev] importlib-metadata
       - name: pylint setup.py tests/ yanico/
         run: |
           pylint setup.py tests/ yanico/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,9 @@ jobs:
       - name: python package installation
         run: |
           pip install -e.[dev]
-      - name: coverage run setup.py test
+      - name: coverage run -m pytest
         run: |
-          coverage run setup.py test
+          coverage run -m pytest
       - name: coverage report
         run: |
           coverage report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,9 +55,9 @@ jobs:
       - name: python package installation
         run: |
           pip install -e.[dev]
-      - name: mypy yanico/
+      - name: mypy yanico/ --install-types
         run: |
-          mypy yanico/
+          mypy yanico/ --install-types
 
   pylint-22:
     runs-on: ubuntu-22.04
@@ -77,8 +77,7 @@ jobs:
           cache: 'pip' # caching pip dependencies
       - name: python package installation
         run: |
-          # Cannot find implementation or library stub for module named "importlib_metadata" (python_version < "3.10")
-          pip install -e.[dev] importlib-metadata
+          pip install -e.[dev]
       - name: pylint setup.py tests/ yanico/
         run: |
           pylint setup.py tests/ yanico/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,9 @@ classifiers = [
   "Topic :: Internet :: WWW/HTTP",
   "Topic :: Internet :: WWW/HTTP :: Session",
 ]
+dependencies = [
+  'importlib-metadata>=4.6.0; python_version<"3.10"',
+]
 
 [project.optional-dependencies]
 develop = ["hacking", "flake8-docstrings", "pep8-naming"]

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -75,12 +75,11 @@ class TestBuildSubparsers(unittest.TestCase):
             parser.set_defaults(run=run)
 
         entry_point = mock.Mock()
-        entry_point.group = "yanico.commands"
         entry_point.name = "stub"
         entry_point.load.return_value = register
         return entry_point
 
-    @mock.patch("importlib.metadata.entry_points")
+    @mock.patch("yanico.command.entry_points")
     def test_stub_command(self, entry_points):
         """Register command returning two times numbers."""
         entry_points.return_value = [self._init_stub_command()]
@@ -89,9 +88,9 @@ class TestBuildSubparsers(unittest.TestCase):
         yanico.command.build_subparsers(parser)
         args = parser.parse_args(["stub", "21"])
         self.assertEqual(args.run(args), 42)
-        entry_points.assert_called_once_with()
+        entry_points.assert_called_once_with(group="yanico.commands")
 
-    @mock.patch("importlib.metadata.entry_points")
+    @mock.patch("yanico.command.entry_points")
     def test_without_arguments(self, entry_points):
         """Expect 'run' method that showing help."""
         entry_points.return_value = [self._init_stub_command()]
@@ -102,7 +101,7 @@ class TestBuildSubparsers(unittest.TestCase):
         with mock.patch.object(parser, "print_help") as print_help:
             args.run(args)
         print_help.assert_called_once_with()
-        entry_points.assert_called_once_with()
+        entry_points.assert_called_once_with(group="yanico.commands")
 
 
 class TestMain(unittest.TestCase):

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -75,6 +75,7 @@ class TestBuildSubparsers(unittest.TestCase):
             parser.set_defaults(run=run)
 
         entry_point = mock.Mock()
+        entry_point.group = "yanico.commands"
         entry_point.name = "stub"
         entry_point.load.return_value = register
         return entry_point
@@ -88,7 +89,7 @@ class TestBuildSubparsers(unittest.TestCase):
         yanico.command.build_subparsers(parser)
         args = parser.parse_args(["stub", "21"])
         self.assertEqual(args.run(args), 42)
-        entry_points.assert_called_once_with(group="yanico.commands")
+        entry_points.assert_called_once_with()
 
     @mock.patch("importlib.metadata.entry_points")
     def test_without_arguments(self, entry_points):
@@ -101,7 +102,7 @@ class TestBuildSubparsers(unittest.TestCase):
         with mock.patch.object(parser, "print_help") as print_help:
             args.run(args)
         print_help.assert_called_once_with()
-        entry_points.assert_called_once_with(group="yanico.commands")
+        entry_points.assert_called_once_with()
 
 
 class TestMain(unittest.TestCase):

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -79,21 +79,21 @@ class TestBuildSubparsers(unittest.TestCase):
         entry_point.load.return_value = register
         return entry_point
 
-    @mock.patch("pkg_resources.iter_entry_points")
-    def test_stub_command(self, iter_entry_points):
+    @mock.patch("importlib.metadata.entry_points")
+    def test_stub_command(self, entry_points):
         """Register command returning two times numbers."""
-        iter_entry_points.return_value = [self._init_stub_command()]
+        entry_points.return_value = [self._init_stub_command()]
 
         parser = argparse.ArgumentParser()
         yanico.command.build_subparsers(parser)
         args = parser.parse_args(["stub", "21"])
         self.assertEqual(args.run(args), 42)
-        iter_entry_points.assert_called_once_with("yanico.commands")
+        entry_points.assert_called_once_with(group="yanico.commands")
 
-    @mock.patch("pkg_resources.iter_entry_points")
-    def test_without_arguments(self, iter_entry_points):
+    @mock.patch("importlib.metadata.entry_points")
+    def test_without_arguments(self, entry_points):
         """Expect 'run' method that showing help."""
-        iter_entry_points.return_value = [self._init_stub_command()]
+        entry_points.return_value = [self._init_stub_command()]
 
         parser = yanico.command.create_main_parser()
         yanico.command.build_subparsers(parser)
@@ -101,7 +101,7 @@ class TestBuildSubparsers(unittest.TestCase):
         with mock.patch.object(parser, "print_help") as print_help:
             args.run(args)
         print_help.assert_called_once_with()
-        iter_entry_points.assert_called_once_with("yanico.commands")
+        entry_points.assert_called_once_with(group="yanico.commands")
 
 
 class TestMain(unittest.TestCase):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -23,24 +23,22 @@ from yanico.session import LoaderNotFoundError
 class TestLoad(unittest.TestCase):
     """Test for yanico.session.load()."""
 
-    @mock.patch("importlib.metadata.entry_points")
+    @mock.patch("yanico.session.entry_points")
     def test_loader_exist(self, entry_points):
         """Expect to the load function returns user session."""
         entry = mock.Mock()
-        entry.group = "yanico.sessions"
-        entry.name = "firefox"
         loader = entry.load.return_value = mock.Mock(return_value="value")
         entry_points.return_value = [entry]
 
-        ltype = entry.name
+        ltype = "firefox"
         profile = "/path/to/profile"
         self.assertEqual(session.load(ltype, profile), "value")
 
-        entry_points.assert_called_once_with()
+        entry_points.assert_called_once_with(group="yanico.sessions", name=ltype)
         entry.load.assert_called_once_with()
         loader.assert_called_once_with(profile)
 
-    @mock.patch("importlib.metadata.entry_points")
+    @mock.patch("yanico.session.entry_points")
     def test_loader_not_exist(self, entry_points):
         """Expect to raise exception when the loader does not exist."""
         eps = entry_points.return_value
@@ -50,9 +48,9 @@ class TestLoad(unittest.TestCase):
         profile = "dummy"
         self.assertRaises(LoaderNotFoundError, session.load, ltype, profile)
 
-        entry_points.assert_called_once_with()
+        entry_points.assert_called_once_with(group="yanico.sessions", name=ltype)
 
-    @mock.patch("importlib.metadata.entry_points")
+    @mock.patch("yanico.session.entry_points")
     def test_loader_error(self, entry_points):
         """Expect to through error when the loader raises any error."""
 
@@ -60,16 +58,14 @@ class TestLoad(unittest.TestCase):
             pass
 
         entry = mock.Mock()
-        entry.group = "yanico.sessions"
-        entry.name = "loader is found"
         loader = entry.load.return_value = mock.Mock(side_effect=_AnyError)
         entry_points.return_value = [entry]
 
-        ltype = entry.name
+        ltype = "loader is found"
         profile = "a profile"
         self.assertRaises(_AnyError, session.load, ltype, profile)
 
-        entry_points.assert_called_once_with()
+        entry_points.assert_called_once_with(group="yanico.sessions", name=ltype)
         entry.load.assert_called_once_with()
         loader.assert_called_once_with(profile)
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -27,14 +27,16 @@ class TestLoad(unittest.TestCase):
     def test_loader_exist(self, entry_points):
         """Expect to the load function returns user session."""
         entry = mock.Mock()
+        entry.group = "yanico.sessions"
+        entry.name = "firefox"
         loader = entry.load.return_value = mock.Mock(return_value="value")
         entry_points.return_value = [entry]
 
-        ltype = "firefox"
+        ltype = entry.name
         profile = "/path/to/profile"
         self.assertEqual(session.load(ltype, profile), "value")
 
-        entry_points.assert_called_once_with(group="yanico.sessions", name=ltype)
+        entry_points.assert_called_once_with()
         entry.load.assert_called_once_with()
         loader.assert_called_once_with(profile)
 
@@ -48,7 +50,7 @@ class TestLoad(unittest.TestCase):
         profile = "dummy"
         self.assertRaises(LoaderNotFoundError, session.load, ltype, profile)
 
-        entry_points.assert_called_once_with(group="yanico.sessions", name=ltype)
+        entry_points.assert_called_once_with()
 
     @mock.patch("importlib.metadata.entry_points")
     def test_loader_error(self, entry_points):
@@ -58,14 +60,16 @@ class TestLoad(unittest.TestCase):
             pass
 
         entry = mock.Mock()
+        entry.group = "yanico.sessions"
+        entry.name = "loader is found"
         loader = entry.load.return_value = mock.Mock(side_effect=_AnyError)
         entry_points.return_value = [entry]
 
-        ltype = "loader is found"
+        ltype = entry.name
         profile = "a profile"
         self.assertRaises(_AnyError, session.load, ltype, profile)
 
-        entry_points.assert_called_once_with(group="yanico.sessions", name=ltype)
+        entry_points.assert_called_once_with()
         entry.load.assert_called_once_with()
         loader.assert_called_once_with(profile)
 

--- a/tests/test_session_firefox.py
+++ b/tests/test_session_firefox.py
@@ -23,7 +23,7 @@ from yanico.session import firefox
 from yanico.session import UserSessionNotFoundError
 
 if sys.version_info < (3, 10):
-    from pkg_resources import load_entry_point
+    from importlib_metadata import entry_points
 else:
     from importlib.metadata import entry_points
 
@@ -74,19 +74,7 @@ class TestLoad(unittest.TestCase):
 class TestEntryPoint(unittest.TestCase):
     """Test for `yanico.sessions` entry point."""
 
-    @unittest.skipIf(
-        sys.version_info >= (3, 10), "python3.10 can use EntryPoints.select API."
-    )
-    def test_load_func_py39(self):
-        """Check whether loaeded function is firefox.load()."""
-        func = load_entry_point("yanico>=0.1.0a2", "yanico.sessions", "firefox")
-        self.assertIs(firefox.load, func)
-
-    @unittest.skipIf(
-        sys.version_info < (3, 10),
-        "python3.9 cannot get entries via importlib.metadata.",
-    )
-    def test_load_func_py310(self):
+    def test_load_func(self):
         """Check whether loaeded function is firefox.load()."""
         (entry,) = entry_points(group="yanico.sessions", name="firefox")
         func = entry.load()

--- a/tests/test_session_firefox.py
+++ b/tests/test_session_firefox.py
@@ -17,8 +17,7 @@ import os.path
 import sqlite3
 import unittest
 from unittest import mock
-
-import pkg_resources
+import importlib.metadata
 
 from yanico.session import firefox
 from yanico.session import UserSessionNotFoundError
@@ -72,7 +71,8 @@ class TestEntryPoint(unittest.TestCase):
 
     def test_load_func(self):
         """Check whether loaeded function is firefox.load()."""
-        func = pkg_resources.load_entry_point(
-            "yanico>=0.1.0a2", "yanico.sessions", "firefox"
+        (entry,) = importlib.metadata.entry_points(
+            group="yanico.sessions", name="firefox"
         )
+        func = entry.load()
         self.assertIs(firefox.load, func)

--- a/tests/test_session_firefox.py
+++ b/tests/test_session_firefox.py
@@ -71,8 +71,7 @@ class TestEntryPoint(unittest.TestCase):
 
     def test_load_func(self):
         """Check whether loaeded function is firefox.load()."""
-        (entry,) = importlib.metadata.entry_points(
-            group="yanico.sessions", name="firefox"
-        )
+        eps = importlib.metadata.entry_points()
+        (entry,) = [e for e in eps["yanico.sessions"] if e.name == "firefox"]
         func = entry.load()
         self.assertIs(firefox.load, func)

--- a/yanico/command/__init__.py
+++ b/yanico/command/__init__.py
@@ -14,7 +14,7 @@
 #  limitations under the License.
 
 import argparse
-import pkg_resources
+import importlib.metadata
 
 import yanico
 
@@ -36,7 +36,7 @@ def build_subparsers(parser):
     """Register command from setuptools plugins."""
     # pylint: disable=no-member
     subparsers = parser.add_subparsers(title="Commands")
-    for entry in pkg_resources.iter_entry_points("yanico.commands"):
+    for entry in importlib.metadata.entry_points(group="yanico.commands"):
         register = entry.load()
         register(entry.name, subparsers)
 

--- a/yanico/command/__init__.py
+++ b/yanico/command/__init__.py
@@ -36,7 +36,9 @@ def build_subparsers(parser):
     """Register command from setuptools plugins."""
     # pylint: disable=no-member
     subparsers = parser.add_subparsers(title="Commands")
-    for entry in importlib.metadata.entry_points(group="yanico.commands"):
+    eps = importlib.metadata.entry_points()
+    select_entries = [e for e in eps if e.group == "yanico.commands"]
+    for entry in select_entries:
         register = entry.load()
         register(entry.name, subparsers)
 

--- a/yanico/command/__init__.py
+++ b/yanico/command/__init__.py
@@ -14,9 +14,14 @@
 #  limitations under the License.
 
 import argparse
-import importlib.metadata
+import sys
 
 import yanico
+
+if sys.version_info < (3, 10):
+    from importlib_metadata import entry_points
+else:
+    from importlib.metadata import entry_points
 
 
 def create_main_parser():
@@ -36,9 +41,8 @@ def build_subparsers(parser):
     """Register command from setuptools plugins."""
     # pylint: disable=no-member
     subparsers = parser.add_subparsers(title="Commands")
-    eps = importlib.metadata.entry_points()
-    select_entries = [e for e in eps if e.group == "yanico.commands"]
-    for entry in select_entries:
+    eps = entry_points(group="yanico.commands")
+    for entry in eps:
         register = entry.load()
         register(entry.name, subparsers)
 

--- a/yanico/session/__init__.py
+++ b/yanico/session/__init__.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 """Handle nicovideo.jp user_session."""
 
-import pkg_resources
+import importlib.metadata
 
 
 class LoaderNotFoundError(Exception):
@@ -38,7 +38,7 @@ def load(ltype, profile):
         LoaderNotFoundError
         Error from loader
     """
-    for entry in pkg_resources.iter_entry_points("yanico.sessions", ltype):
+    for entry in importlib.metadata.entry_points(group="yanico.sessions", name=ltype):
         load_func = entry.load()
         return load_func(profile)
     raise LoaderNotFoundError(f"{ltype} loader is not found.")

--- a/yanico/session/__init__.py
+++ b/yanico/session/__init__.py
@@ -38,7 +38,11 @@ def load(ltype, profile):
         LoaderNotFoundError
         Error from loader
     """
-    for entry in importlib.metadata.entry_points(group="yanico.sessions", name=ltype):
+    eps = importlib.metadata.entry_points()
+    select_entries = [
+        e for e in eps if e.group == "yanico.sessions" and e.name == ltype
+    ]
+    for entry in select_entries:
         load_func = entry.load()
         return load_func(profile)
     raise LoaderNotFoundError(f"{ltype} loader is not found.")

--- a/yanico/session/__init__.py
+++ b/yanico/session/__init__.py
@@ -13,7 +13,12 @@
 #  limitations under the License.
 """Handle nicovideo.jp user_session."""
 
-import importlib.metadata
+import sys
+
+if sys.version_info < (3, 10):
+    from importlib_metadata import entry_points
+else:
+    from importlib.metadata import entry_points
 
 
 class LoaderNotFoundError(Exception):
@@ -38,11 +43,8 @@ def load(ltype, profile):
         LoaderNotFoundError
         Error from loader
     """
-    eps = importlib.metadata.entry_points()
-    select_entries = [
-        e for e in eps if e.group == "yanico.sessions" and e.name == ltype
-    ]
-    for entry in select_entries:
+    eps = entry_points(group="yanico.sessions", name=ltype)
+    for entry in eps:
         load_func = entry.load()
         return load_func(profile)
     raise LoaderNotFoundError(f"{ltype} loader is not found.")


### PR DESCRIPTION
`pkg_resources` module has been deprecated.
`importlib.metadata` is introduced since python 3.8.
