### PR TITLE
Use setuptools_scm to get version number from git revision

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,11 +42,13 @@ Requirement
 * Python_ (バージョン3.8以降)
 * pip_ (バージョン10以降)
 * setuptools_ (バージョン 61.0.0 以降)
+* setuptools_scm_
 * サードパーティ製のHTTPライブラリ(予定)
 
 .. _Python: https://www.python.org/
 .. _pip: https://pip.pypa.io/
-.. _setuptools: http://pythonhosted.org/setuptools/
+.. _setuptools: https://setuptools.pypa.io/
+.. _setuptools_scm: https://pypi.org/project/setuptools-scm/
 
 
 Install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ develop = ["hacking", "flake8-docstrings", "pep8-naming"]
 dev = [
   "black>=23.7.0",
   "coverage",
-  "docutils",
+  "docutils>=0.20,<0.21",
   "mypy>=0.560",
   "pylint>=2.6.0",
   "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=61.0", "setuptools_scm"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -76,8 +76,7 @@ firefox = "yanico.session.firefox:load"
 [tool.setuptools.packages.find]
 exclude = ["tests"]
 
-[tool.setuptools.dynamic]
-version = {attr = "yanico.__version__"}
+[tool.setuptools_scm]
 
 [tool.black]
 line-length = 88

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,5 @@
 """yanico test module."""
+
 #  Copyright 2015 Masayuki Yamamoto
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -1,4 +1,5 @@
 """Unittest of command entry point."""
+
 #  Copyright 2015 Masayuki Yamamoto
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_session_firefox.py
+++ b/tests/test_session_firefox.py
@@ -1,4 +1,5 @@
 """Unittest of firefox session."""
+
 #  Copyright 2015-2016 Masayuki Yamamoto
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/yanico/__init__.py
+++ b/yanico/__init__.py
@@ -1,5 +1,5 @@
 """Yet Another Niconico-douga Command-line Interface."""
-#  Copyright 2015-2023 Masayuki Yamamoto
+#  Copyright 2015-2024 Masayuki Yamamoto
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -13,8 +13,14 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from importlib.metadata import PackageNotFoundError, version
+
 __author__ = "Masayuki Yamamoto"
-__copyright__ = "Copyright 2015-2016 Yamamoto Masayuki"
+__copyright__ = "Copyright 2015-2024 Yamamoto Masayuki"
 __description__ = __doc__
 __license__ = "Apache 2.0"
-__version__ = "0.1.0a4"
+
+try:
+    __version__ = version(__name__)
+except PackageNotFoundError:
+    __version__ = "unknown"

--- a/yanico/__init__.py
+++ b/yanico/__init__.py
@@ -1,4 +1,5 @@
 """Yet Another Niconico-douga Command-line Interface."""
+
 #  Copyright 2015-2024 Masayuki Yamamoto
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/yanico/__main__.py
+++ b/yanico/__main__.py
@@ -1,4 +1,5 @@
 """Command entry point."""
+
 #  Copyright 2015 Masayuki Yamamoto
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/yanico/command/__init__.py
+++ b/yanico/command/__init__.py
@@ -1,4 +1,5 @@
 """Command entry point."""
+
 #  Copyright 2015 Masayuki Yamamoto
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/yanico/session/firefox.py
+++ b/yanico/session/firefox.py
@@ -1,4 +1,5 @@
 """Handle Firefox session."""
+
 #  Copyright 2015-2016 Masayuki Yamamoto
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
### Use setuptools_scm to get version number from git revision

- Updated README.rst to include `setuptools_scm` as a requirement.
- Modified pyproject.toml to use `setuptools_scm` for versioning.
- Adjusted `__init__.py` to retrieve the version number using `importlib.metadata`'s version function.
- Updated the copyright year to 2024.

### style: fix coding style by black

###     Fix CI jobs for docutils

Docutils 0.21 and later versions do not support Python 3.8.
https://docutils.sourceforge.io/RELEASE-NOTES.html#release-0-21-2024-04-09


